### PR TITLE
chore: 🤖 Making the JS build compatible with zdebugger

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,19 +7,25 @@
  */
 
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalDistributionDsl
+
+// Constants
+val zernikalosName = "zernikalos"
+val zernikalosNameCapital = "Zernikalos"
+val zernikalosFullName = "io.zernikalos"
+val zernikalosVersion = "0.0.1"
 
 plugins {
     kotlin("multiplatform") apply true
     id("com.android.library") apply true
     id("org.jetbrains.kotlin.android") apply false
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("maven-publish")
     // id("org.lwjgl.plugin") apply true
     // id("org.jlleitschuh.gradle.ktlint")
 }
 
-group = "zernikalos"
-version = "0.0.1"
+group = zernikalosName
+version = zernikalosVersion
 
 repositories {
     mavenLocal()
@@ -29,13 +35,13 @@ repositories {
 }
 
 android {
-    namespace="io.zernikalos"
+    namespace=zernikalosFullName
     compileSdk=33
 
     defaultConfig {
         minSdk=24
 
-        version="0.0.1"
+        version=zernikalosVersion
 
         testInstrumentationRunner="androidx.test.runner.AndroidJUnitRunner"
         // consumerProguardFiles="consumer-rules.pro"
@@ -73,13 +79,13 @@ kotlin {
         }
         browser {
             binaries.executable()
-            @OptIn(ExperimentalDistributionDsl::class)
-            distribution {
-                outputDirectory = File("$projectDir/output/")
-            }
+//            @OptIn(ExperimentalDistributionDsl::class)
+//            distribution {
+//                outputDirectory = File("$projectDir/output/")
+//            }
             commonWebpackConfig {
                 output?.libraryTarget = "umd"
-                output?.library = "zernikalos"
+                output?.library = zernikalosName
                 mode = org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig.Mode.DEVELOPMENT
                 sourceMaps = true
             }
@@ -95,37 +101,19 @@ kotlin {
 //        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
 //    }
 
-    val appleFrameworkBaseName = "Zernikalos"
+    val xcf = XCFramework(zernikalosNameCapital)
+    val appleTargets = listOf(macosArm64(), iosArm64(), iosSimulatorArm64())
 
-    val xcf = XCFramework(appleFrameworkBaseName)
-
-    macosArm64() {
-        binaries.framework {
+    appleTargets.forEach {
+        it.binaries.framework {
             isStatic = true
-            baseName = appleFrameworkBaseName
-            binaryOption("bundleId", "io.zernikalos")
+            baseName = zernikalosNameCapital
+            binaryOption("bundleId", zernikalosFullName)
+            binaryOption("bundleVersion", zernikalosVersion)
+            debuggable = true
             xcf.add(this)
         }
     }
-
-    iosArm64() {
-        binaries.framework {
-            isStatic = true
-            baseName = appleFrameworkBaseName
-            binaryOption("bundleId", "io.zernikalos")
-            xcf.add(this)
-        }
-    }
-
-    iosSimulatorArm64() {
-        binaries.framework {
-            isStatic = true
-            baseName = appleFrameworkBaseName
-            binaryOption("bundleId", "io.zernikalos")
-            xcf.add(this)
-        }
-    }
-
     
     sourceSets {
         all {
@@ -160,6 +148,10 @@ kotlin {
         }
 
         jsMain {
+            // Required for compatibility with zdebugger (see webpack file)
+            dependencies {
+                implementation(devNpm("string-replace-loader", "3.1.0"))
+            }
             dependsOn(oglMain)
         }
 
@@ -172,15 +164,6 @@ kotlin {
             dependsOn(metalMain)
             kotlin.srcDir("src/iosMain/kotlin")
         }
-
-//        val iosMain by getting {
-//            dependsOn(metalMain)
-//            kotlin.srcDir("src/iosMain/kotlin")
-//        }
-//
-//        val iosSimulatorArm64Main by getting {
-//            dependsOn(iosMain)
-//        }
 
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,21 @@
-kotlin.code.style=official
-kotlin.js.compiler=ir
-kotlin.mpp.androidSourceSetLayoutVersion=2
+#
+# Copyright (c) 2024. Aarón Negrín - Zernikalos Engine.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+
 org.gradle.jvmargs=-Xmx2048m
+
+kotlin.code.style=official
+kotlin.mpp.applyDefaultHierarchyTemplate=false
+kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.mpp.enableCInteropCommonization=true
 
 # kotlin.experimental.tryK2=true
 # kapt.use.k2=true
-kotlin.mpp.applyDefaultHierarchyTemplate=false
+# kotlin.js.compiler=ir
+kotlin.js.ir.output.granularity=per-module
+kotlin.js.yarn=false
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,10 +7,11 @@
  */
 
 rootProject.name = "zernikalos"
+include(":zernikalos")
 
 pluginManagement {
     plugins {
-        val kotlinPluginVersion = "2.0.0-RC3"
+        val kotlinPluginVersion = "2.0.0"
         val androidPluginVer = "8.1.0"
 
         kotlin("multiplatform") version kotlinPluginVersion

--- a/src/commonMain/kotlin/zernikalos/logger/ZLogger.kt
+++ b/src/commonMain/kotlin/zernikalos/logger/ZLogger.kt
@@ -69,7 +69,7 @@ class ZLogger(private val clsName: String?, val instanceId: Int) {
     private fun prettyLogLevel(levelName: String): String {
         val max = ZLogLevel.entries.map { it.name }.maxBy { it.length }
         val extraSpaces = max.length - levelName.length
-        return "${levelName}${" ".repeat(extraSpaces)}"
+        return "[Zernikalos - ${levelName}]${" ".repeat(extraSpaces)}"
         }
 
     companion object {

--- a/webpack.config.d/webpack-config.js
+++ b/webpack.config.d/webpack-config.js
@@ -12,4 +12,20 @@ config.output.library = {
     export: "zernikalos"
 };
 
-config.devtool = 'source-map';
+// config.devtool = 'source-map';
+
+// Related to this issue https://github.com/Kotlin/kotlinx.coroutines/issues/3874
+// Need to modify the naming on the window
+config.module = {
+    rules: [
+        {
+            test: /\.js$/,
+            loader: 'string-replace-loader',
+            options: {
+                search: 'coroutineDispatcher',
+                replace: 'zkCoroutineDispatcher',
+                flags: 'g'
+            }
+        }
+    ]
+}


### PR DESCRIPTION
In this commit, a new module for webpack with a rules array has been added to handle an issue related to 'kotlinx.coroutines'. The kotlin plugin version has been updated from '2.0.0-RC3' to '2.0.0'. Moreover, various constants have been introduced to replace hardcoded strings.