### PR TITLE
fix: 🐛 Reusing uniforms and attributes leads to errors

### DIFF
--- a/src/commonMain/kotlin/zernikalos/components/shader/ZAttribute.kt
+++ b/src/commonMain/kotlin/zernikalos/components/shader/ZAttribute.kt
@@ -19,24 +19,32 @@ import zernikalos.context.ZRenderingContext
 import kotlin.js.JsExport
 import kotlin.js.JsName
 
-enum class ZAttributeId(val id: Int) {
-    INDICES(0),
-    POSITION(1),
-    NORMAL(2),
-    COLOR(3),
-    UV(4),
-    BONE_WEIGHT(5),
-    BONE_INDEX(6)
+@JsExport
+enum class ZAttributeId(val id: Int, val attrName: String) {
+    INDICES(0, "indices"),
+    POSITION(1, "a_position"),
+    NORMAL(2, "a_normal"),
+    COLOR(3, "a_color"),
+    UV(4, "a_uv"),
+    BONE_WEIGHT(5, "a_boneWeight"),
+    BONE_INDEX(6, "a_boneIndices")
 }
 
-// TODO: These guys are incorrect, they need to provide a new attribute each time
-val ZAttrIndices = ZAttribute(0, "indices")
-val ZAttrPosition = ZAttribute(1, "a_position")
-val ZAttrNormal = ZAttribute(2, "a_normal")
-val ZAttrColor = ZAttribute(3, "a_color")
-val ZAttrUv = ZAttribute(4, "a_uv")
-val ZAttrBoneWeight = ZAttribute(5, "a_boneWeight")
-val ZAttrBoneIndices = ZAttribute(6, "a_boneIndices")
+
+val ZAttrIndices: ZAttribute
+    get() = ZAttribute(ZAttributeId.INDICES)
+val ZAttrPosition: ZAttribute
+    get() = ZAttribute(ZAttributeId.POSITION)
+val ZAttrNormal: ZAttribute
+    get() = ZAttribute(ZAttributeId.NORMAL)
+val ZAttrColor: ZAttribute
+    get() = ZAttribute(ZAttributeId.COLOR)
+val ZAttrUv: ZAttribute
+    get() = ZAttribute(ZAttributeId.UV)
+val ZAttrBoneWeight: ZAttribute
+    get() = ZAttribute(ZAttributeId.BONE_WEIGHT)
+val ZAttrBoneIndices: ZAttribute
+    get() = ZAttribute(ZAttributeId.BONE_INDEX)
 
 @JsExport
 @Serializable(with = ZAttributeSerializer::class)
@@ -47,6 +55,9 @@ class ZAttribute internal constructor(data: ZAttributeData): ZComponent<ZAttribu
 
     @JsName("initWithArgs")
     constructor(id: Int, attributeName: String): this(ZAttributeData(id, attributeName))
+
+    @JsName("initWithAttrId")
+    constructor(attrId: ZAttributeId): this(ZAttributeData(attrId.id, attrId.attrName))
 
     var id: Int by data::id
 

--- a/src/commonMain/kotlin/zernikalos/components/shader/ZUniform.kt
+++ b/src/commonMain/kotlin/zernikalos/components/shader/ZUniform.kt
@@ -23,9 +23,12 @@ import kotlin.js.JsExport
 import kotlin.js.JsName
 
 // TODO: These guys are incorrect, they need to provide a new uniform each time
-val ZUniformProjectionMatrix = ZUniform("u_projMatrix", 1, ZTypes.MAT4F)
-val ZUniformViewMatrix = ZUniform("u_viewMatrix", 1, ZTypes.MAT4F)
-val ZUniformModelViewProjectionMatrix = { ZUniform("u_mvpMatrix", 1, ZTypes.MAT4F) }
+val ZUniformProjectionMatrix: ZUniform
+    get() = ZUniform("u_projMatrix", 1, ZTypes.MAT4F)
+val ZUniformViewMatrix: ZUniform
+    get() = ZUniform("u_viewMatrix", 1, ZTypes.MAT4F)
+val ZUniformModelViewProjectionMatrix: ZUniform
+    get() = ZUniform("u_mvpMatrix", 1, ZTypes.MAT4F)
 
 @Serializable(with = ZUniformSerializer::class)
 @JsExport


### PR DESCRIPTION
Since attributes, for instance, set an specific id on the ogl layer this might lead to unexpected behaviors. This change will create a new one everytime it is needed to