### PR TITLE
feat: 🎸 Support for flipped textures

### DIFF
--- a/src/commonMain/kotlin/zernikalos/components/material/ZTexture.kt
+++ b/src/commonMain/kotlin/zernikalos/components/material/ZTexture.kt
@@ -24,13 +24,17 @@ class ZTexture internal constructor(data: ZTextureData): ZRefComponent<ZTextureD
     constructor(): this(ZTextureData())
 
     @JsName("initWithArgs")
-    constructor(id: String, width: Int, height: Int, dataArray: ByteArray): this(ZTextureData(id, width, height, dataArray))
+    constructor(id: String, width: Int, height: Int, flipX: Boolean, flipY: Boolean, dataArray: ByteArray): this(ZTextureData(id, width, height, flipX, flipY, dataArray))
 
     var id: String by data::id
 
     var width: Int by data::width
 
     var height: Int by data::height
+
+    var flipX: Boolean by data::flipX
+
+    var flipY: Boolean by data::flipY
 
     var dataArray: ByteArray by data::dataArray
 
@@ -66,6 +70,10 @@ data class ZTextureData(
     @ProtoNumber(3)
     var height: Int = 0,
     @ProtoNumber(4)
+    var flipX: Boolean = false,
+    @ProtoNumber(5)
+    var flipY: Boolean = false,
+    @ProtoNumber(10)
     var dataArray: ByteArray = byteArrayOf(),
 ): ZComponentData() {
 

--- a/src/commonMain/kotlin/zernikalos/generators/shadergenerator/ShaderSourceGenerator.kt
+++ b/src/commonMain/kotlin/zernikalos/generators/shadergenerator/ShaderSourceGenerator.kt
@@ -17,6 +17,7 @@ class ZAttributesEnabler {
     var useColors: Boolean = false
     var useTextures: Boolean = false
     var useSkinning: Boolean = false
+    var flipTextureY: Boolean = false
 }
 
 expect class ZShaderSourceGenerator(): ZLoggable {

--- a/src/commonMain/kotlin/zernikalos/loader/ZkoFormat.kt
+++ b/src/commonMain/kotlin/zernikalos/loader/ZkoFormat.kt
@@ -9,12 +9,22 @@
 package zernikalos.loader
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.protobuf.ProtoNumber
+
+const val ZKO_VERSION = "0.2.0"
 
 @Serializable
 data class ZkoHeader(
     @ProtoNumber(1) val version: String
-)
+) {
+    init {
+        require(version == ZKO_VERSION) {
+            throw SerializationException("Wrong ZKO file version, expecting $ZKO_VERSION, got $version")
+        }
+
+    }
+}
 
 @Serializable
 data class ZkoFormat(

--- a/src/commonMain/kotlin/zernikalos/objects/ZModel.kt
+++ b/src/commonMain/kotlin/zernikalos/objects/ZModel.kt
@@ -108,7 +108,12 @@ class ZModel: ZObject(), ZLoggable {
         enabler.usePosition = mesh.hasBufferKey("position")
         enabler.useColors = mesh.hasBufferKey("color")
         //enabler.useNormals = mesh.hasBufferKey("normal")
-        enabler.useTextures = hasTextures
+        if (hasTextures) {
+            enabler.useTextures = hasTextures
+            if (material?.texture?.flipY == true) {
+                enabler.flipTextureY = true
+            }
+        }
         return enabler
     }
 

--- a/src/metalMain/kotlin/zernikalos/generators/shadergenerator/ShaderSourceGenerator.metal.kt
+++ b/src/metalMain/kotlin/zernikalos/generators/shadergenerator/ShaderSourceGenerator.metal.kt
@@ -21,6 +21,7 @@ actual class ZShaderSourceGenerator : ZLoggable {
         if (enabler.useNormals) source = "#define USE_NORMAL\n$source"
         if (enabler.useColors) source = "#define USE_COLOR\n$source"
         if (enabler.useTextures) source = "#define USE_TEXTURE\n$source"
+        if (enabler.flipTextureY) source = "#define FLIP_TEXTURE_Y\n$source"
 
         return source
     }

--- a/src/metalMain/kotlin/zernikalos/generators/shadergenerator/libs/ZDefaultShader.kt
+++ b/src/metalMain/kotlin/zernikalos/generators/shadergenerator/libs/ZDefaultShader.kt
@@ -46,8 +46,13 @@ ColorInOut computeOutColor(Vertex in) {
     ColorInOut out;
 
     #if defined(USE_TEXTURE)
-        out.texCoord.x = in.texCoord.x;
-        out.texCoord.y = in.texCoord.y;
+        #if defined(FLIP_TEXTURE_Y)
+            out.texCoord.x = in.texCoord.x;
+            out.texCoord.y = 1.0 - in.texCoord.y;
+        #else
+            out.texCoord.x = in.texCoord.x;
+            out.texCoord.y = in.texCoord.y;
+        #endif
     #elif defined(USE_COLOR)
         out.color = in.color;
     #else
@@ -90,7 +95,8 @@ const val shaderFragmentMain = """
     float4 fragmentComputeColorOutFromTexture(ColorInOut in, texture2d<half> colorMap) {
         constexpr sampler colorSampler(mip_filter::linear,
                                        mag_filter::linear,
-                                       min_filter::linear);
+                                       min_filter::linear,
+                                       address::repeat);
     
         half4 colorSample = colorMap.sample(colorSampler, in.texCoord.xy);
     

--- a/src/oglMain/kotlin/zernikalos/generators/shadergenerator/ShaderSourceGenerator.ogl.kt
+++ b/src/oglMain/kotlin/zernikalos/generators/shadergenerator/ShaderSourceGenerator.ogl.kt
@@ -32,6 +32,7 @@ actual class ZShaderSourceGenerator : ZLoggable {
         if (enabler.useNormals) shaderSource = "#define USE_NORMALS\n$shaderSource"
         if (enabler.useColors) shaderSource = "#define USE_COLORS\n$shaderSource"
         if (enabler.useTextures) shaderSource = "#define USE_TEXTURES\n$shaderSource"
+        if (enabler.flipTextureY) shaderSource = "#define FLIP_TEXTURE_Y\n$shaderSource"
 
         shaderSource = "#version 300 es\n$shaderSource"
 

--- a/src/oglMain/kotlin/zernikalos/generators/shadergenerator/libs/ZDefaultShader.kt
+++ b/src/oglMain/kotlin/zernikalos/generators/shadergenerator/libs/ZDefaultShader.kt
@@ -38,8 +38,12 @@ in vec3 a_position;
 void main() {
     gl_Position = u_mvpMatrix * vec4(a_position,1);
    
-#ifdef USE_TEXTURES 
-    v_uv = a_uv;
+#ifdef USE_TEXTURES
+    #ifdef FLIP_TEXTURE_Y
+        v_uv = vec2(a_uv.x, 1.0 - a_uv.y);;
+    #else
+        v_uv = a_uv;
+    #endif
 #endif
 #ifdef USE_COLORS
     v_color = a_color;


### PR DESCRIPTION
With these changes support for flipped textures is given, temporary directives has been added to the shaders. Also a more strict change detection on the Zko version is provided.