### PR TITLE
fix: 🐛 Fixing error for OGl affecting performance

### DIFF
--- a/src/androidMain/kotlin/zernikalos/context/ZRenderingContext.kt
+++ b/src/androidMain/kotlin/zernikalos/context/ZRenderingContext.kt
@@ -134,8 +134,10 @@ actual class ZGLRenderingContext actual constructor(val surfaceView: ZSurfaceVie
     }
 
     actual fun bufferData(targetType: BufferTargetType, dataArray: ByteArray, usageType: BufferUsageType) {
-        val buff = ByteBuffer.wrap(dataArray)
-        GLES30.glBufferData(targetType.value, dataArray.size, buff, usageType.value)
+        val buffer = ByteBuffer.allocateDirect(dataArray.size)
+        buffer.put(dataArray)
+        buffer.position(0)
+        GLES30.glBufferData(targetType.value, dataArray.size, buffer, usageType.value)
     }
 
     actual fun bufferData(targetType: BufferTargetType, byteSize: Int, usageType: BufferUsageType) {

--- a/src/commonMain/kotlin/zernikalos/action/ZActionPlayer.kt
+++ b/src/commonMain/kotlin/zernikalos/action/ZActionPlayer.kt
@@ -6,6 +6,9 @@ import kotlin.js.JsExport
 import kotlin.time.Clock.System
 import kotlin.time.ExperimentalTime
 
+/**
+ * @suppress
+ */
 @OptIn(ExperimentalTime::class)
 fun System.currentTimeMillis(): Long = System.now().toEpochMilliseconds()
 

--- a/src/webgpuMain/kotlin/zernikalos/components/mesh/ZBufferRenderer.wgpu.kt
+++ b/src/webgpuMain/kotlin/zernikalos/components/mesh/ZBufferRenderer.wgpu.kt
@@ -20,8 +20,6 @@ import zernikalos.context.webgpu.GPUVertexStepMode
 
 actual class ZBufferRenderer actual constructor(ctx: ZRenderingContext, private val data: ZBufferData) : ZComponentRenderer(ctx) {
 
-
-
     actual override fun initialize() {
         if (!data.content.isInitialized) {
             data.content.initialize(ctx)
@@ -33,7 +31,7 @@ actual class ZBufferRenderer actual constructor(ctx: ZRenderingContext, private 
         // Use the stride from data, which includes interleaved stride when buffers are interleaved
         // When stride is 0, it means tightly packed, so use element size
         val strideBytes = if (data.stride == 0) data.dataType.byteSize else data.stride
-        
+
         return GPUVertexBufferLayout(
             attributes = arrayOf(
                 GPUVertexAttribute(

--- a/src/webgpuMain/kotlin/zernikalos/components/mesh/ZMeshRenderer.wgpu.kt
+++ b/src/webgpuMain/kotlin/zernikalos/components/mesh/ZMeshRenderer.wgpu.kt
@@ -53,10 +53,10 @@ actual class ZMeshRenderer actual constructor(ctx: ZRenderingContext, private va
         val indices = data.indexBuffer!!
 
         enabledVertexBuffers
-        .sortedBy { it.id } // Use the same consistent order
-        .forEach{ buff -> // Use index for the slot
-            buff.bind()
-        }
+            .sortedBy { it.id } // Use the same consistent order
+            .forEach{ buff -> // Use index for the slot
+                buff.bind()
+            }
         indices.renderer.bindIndexBuffer()
     }
 

--- a/src/webgpuMain/kotlin/zernikalos/objects/ZModelRenderer.wgpu.kt
+++ b/src/webgpuMain/kotlin/zernikalos/objects/ZModelRenderer.wgpu.kt
@@ -54,6 +54,7 @@ actual class ZModelRenderer actual constructor(private val ctx: ZRenderingContex
         }
 
         val renderPipelineDescriptor = GPURenderPipelineDescriptor(
+            label = "${model.name} RenderPipeline",
             layout = ctx.device.createPipelineLayout(
                 GPUPipelineLayoutDescriptor(
                     bindGroupLayouts = bindGroupLayouts.toTypedArray()


### PR DESCRIPTION
Looks like ByteBuffer.wrap blocks the JNI instead of just sending the native location of the data as we are doing right now