### PR TITLE
fix: 🐛 Errors when disposing webgpu instances

### DIFF
--- a/engine/src/commonMain/kotlin/zernikalos/scenestatehandler/ZCreateSurfaceViewEventHandler.kt
+++ b/engine/src/commonMain/kotlin/zernikalos/scenestatehandler/ZCreateSurfaceViewEventHandler.kt
@@ -45,6 +45,7 @@ private class ZSurfaceViewEventHandlerImpl(
     override fun onRender() {
         progressInitialization()
         if (initState == InitState.READY) {
+            if (context.screenWidth <= 0 || context.screenHeight <= 0) return
             performRender()
         }
     }

--- a/engine/src/webgpuMain/kotlin/zernikalos/components/ZViewportRenderer.kt
+++ b/engine/src/webgpuMain/kotlin/zernikalos/components/ZViewportRenderer.kt
@@ -52,6 +52,11 @@ actual class ZViewportRenderer actual constructor(ctx: ZRenderingContext, privat
     private fun createRenderPassDescriptor() {
         ctx as ZWebGPURenderingContext
 
+        if (data.viewBox.width <= 0 || data.viewBox.height <= 0) {
+            renderPassDescriptor = null
+            return
+        }
+
         val textureView = ctx.webGPUContext?.getCurrentTexture()?.createView()
         val depthView = depthTexture?.createView()
 

--- a/engine/src/webgpuMain/kotlin/zernikalos/renderer/ZRenderer.wgpu.kt
+++ b/engine/src/webgpuMain/kotlin/zernikalos/renderer/ZRenderer.wgpu.kt
@@ -33,7 +33,10 @@ actual class ZRenderer actual constructor(ctx: ZContext): ZRendererBase(ctx) {
         // TODO: Remove this thing from here
         ctx.scene!!.viewport.render()
 
-        gpuCtx.createRenderPass(ctx.scene!!.viewport.renderer.renderPassDescriptor!!.toGpu())
+        val descriptor = ctx.scene!!.viewport.renderer.renderPassDescriptor
+        if (descriptor == null) return
+
+        gpuCtx.createRenderPass(descriptor.toGpu())
         ctx.scene!!.render(ctx)
         gpuCtx.renderPass?.end()
 

--- a/engine/src/webgpuMain/kotlin/zernikalos/ui/ZSurfaceView.kt
+++ b/engine/src/webgpuMain/kotlin/zernikalos/ui/ZSurfaceView.kt
@@ -110,16 +110,19 @@ class ZJsSurfaceView(val canvas: HTMLCanvasElement): ZSurfaceView {
     }
 
     override fun dispose() {
-        _eventHandler?.dispose()
-        _eventHandler = null
+        // Stop render loop first so no onRender() runs after we start cleanup
         val rendererIntervalId = this.rendererIntervalId
         if (rendererIntervalId != null) {
             window.clearInterval(rendererIntervalId)
+            this.rendererIntervalId = null
         }
         val animationFrameRequestId = this.animationFrameRequestId
         if (animationFrameRequestId != null) {
             window.cancelAnimationFrame(animationFrameRequestId)
+            this.animationFrameRequestId = null
         }
+        _eventHandler?.dispose()
+        _eventHandler = null
         resizeObserver.disconnect()
         inputEventManager.dispose()
     }
@@ -128,6 +131,8 @@ class ZJsSurfaceView(val canvas: HTMLCanvasElement): ZSurfaceView {
      * Handles resize events from ResizeObserver.
      * Updates canvas dimensions with proper device pixel ratio scaling
      * and notifies the event handler.
+     * Skips update when width or height is 0 (e.g. tab hidden) to avoid
+     * WebGPU swapchain texture of size 0 errors.
      *
      * @param entries Array of ResizeObserverEntry objects containing resize information
      */
@@ -142,6 +147,10 @@ class ZJsSurfaceView(val canvas: HTMLCanvasElement): ZSurfaceView {
 
                         val width: Int = (contentRect.width as Double * dpr).toInt()
                         val height: Int = (contentRect.height as Double * dpr).toInt()
+
+                        if (width <= 0 || height <= 0) {
+                            return@requestAnimationFrame
+                        }
 
                         canvas.width = width
                         canvas.height = height


### PR DESCRIPTION
This will no trigger anymore the issue related with a texture with 0x0 size