### PR TITLE
fix: 🐛 Weird and pale colors on Metal

### DIFF
--- a/engine/src/metalMain/kotlin/zernikalos/generators/shadergenerator/libs/ZDefaultShader.metal.kt
+++ b/engine/src/metalMain/kotlin/zernikalos/generators/shadergenerator/libs/ZDefaultShader.metal.kt
@@ -473,10 +473,8 @@ float3 calculateBlinnPhongColorNoLighting(
 #endif
 
 #if defined(USE_TEXTURE)
-    float4 fragmentComputeColorOutFromTexture(ColorInOut in, texture2d<half> colorMap, sampler colorSampler) {
-        half4 colorSample = colorMap.sample(colorSampler, in.texCoord.xy);
-
-        return float4(colorSample);
+    float4 fragmentComputeColorOutFromTexture(ColorInOut in, texture2d<float> colorMap, sampler colorSampler) {
+        return colorMap.sample(colorSampler, in.texCoord.xy);
     }
 #endif
 
@@ -497,7 +495,7 @@ fragment float4 fragmentShader(ColorInOut in [[stage_in]],
                                , constant AmbientLightUniforms &ambientLight [[buffer(${UNIFORM_IDS.BLOCK_AMBIENT_LIGHT})]]
                                #endif
                                #if defined(USE_TEXTURE)
-                               , texture2d<half> colorMap     [[ texture(0) ]]
+                               , texture2d<float> colorMap     [[ texture(0) ]]
                                , sampler colorSampler         [[ sampler(0) ]]
                                #endif
                                )

--- a/engine/src/metalMain/kotlin/zernikalos/renderer/ZRenderer.metal.kt
+++ b/engine/src/metalMain/kotlin/zernikalos/renderer/ZRenderer.metal.kt
@@ -26,7 +26,8 @@ actual class ZRenderer actual constructor(ctx: ZContext) : ZRendererBase(ctx) {
         depthState = renderingContext.device.newDepthStencilStateWithDescriptor(depthDescriptor)
 
         nativeView.depthStencilPixelFormat = MTLPixelFormatDepth32Float_Stencil8//MTLPixelFormat.depth32Float_stencil8
-        nativeView.colorPixelFormat = MTLPixelFormatBGRA8Unorm_sRGB //MTLPixelFormat.bgra8Unorm_srgb
+        // Linear framebuffer: applyTonemapping already outputs sRGB via pow(1/2.2), matching Web/Android.
+        nativeView.colorPixelFormat = MTLPixelFormatBGRA8Unorm
         nativeView.sampleCount = 1u
     }
 


### PR DESCRIPTION
This was caused by a double gamma application, one in the framebuffer, since Metal applies automatically a sRGB curve And we are also doing that at shader level.
Double gammification was causing the issue